### PR TITLE
[Mozilla Branding Removal] Update README repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
-# Avatar assets and templates for Mozilla Hubs
+# Avatar assets and templates for Hubs
 
-This contains some useful working files for editing avatars for Hubs 
+This contains some useful working files for editing avatars for Hubs
 
-**IMPORTANT:  If you are cloning this repo, _you MUST first install [GitLFS](https://git-lfs.github.com/)_ or else many of the files will not work.**
+**IMPORTANT: If you are cloning this repo, _you MUST first install [GitLFS](https://git-lfs.github.com/)_ or else many of the files will not work.**
 
 Depending on how involved you'd like to get in the avatar creation process, you might choose to simply 're-skin' the existing robot avatar by painting your own texture maps, or create your own fully custom 3D model.
 
 ## Reduce Cloning Size
+
 Cloning the full repository can be difficult on a slow connection due to its large size. The majority of this comes from `Substance/`, which is several GB, and is not necessary unless you intend on using Substance Painter when customizing an avatar. If you do not intend to modify the avatars using Substance Painter, you can exclude the files in `Substance/` from being downloaded by GitLFS by following these commands:
+
 ```
 mkdir hubs-avatar-pipelines && cd hubs-avatar-pipelines
 git init
-git remote add -f origin https://github.com/MozillaReality/hubs-avatar-pipelines.git
+git remote add -f origin https://github.com/Hubs-Foundation/hubs-avatar-pipelines.git
 git config lfs.fetchexclude "Substance"
 git pull origin master
 ```
+
 This reduces the project download size from several GB to less than one GB.
 
 ## Making your own custom avatar skin
@@ -23,11 +26,11 @@ A quick and easy way to create a custom avatar in Hubs is to create a custom ski
 
 You can use the following resources:
 
-* [Quilt](https://tryquilt.io/) - A simple tool put together by the Hubs team for quickly re-skinning the default Hubs robot avatar. 
+- [Quilt](https://tryquilt.io/) - A simple tool put together by the Hubs team for quickly re-skinning the default Hubs robot avatar.
 
-* [Photoshop PSD Templates](Photoshop) - Photoshop templates for a custom Hubs base color skin. You can also use Photoshop's 3D painting tools, using the [Robot OBJ/MAT file](https://github.com/j-conrad/hubs-avatar-pipelines/tree/master/Other%20model%20formats).
+- [Photoshop PSD Templates](Photoshop) - Photoshop templates for a custom Hubs base color skin. You can also use Photoshop's 3D painting tools, using the [Robot OBJ/MAT file](https://github.com/j-conrad/hubs-avatar-pipelines/tree/master/Other%20model%20formats).
 
-* [Substaince Painter Project](Substance) - Full [Substance Painter](https://www.allegorithmic.com/products/substance-painter) projects for advanced custom skinning. You can also download and modify any of our [example texture sets](Exported%20Texture%20Sets).
+- [Substaince Painter Project](Substance) - Full [Substance Painter](https://www.allegorithmic.com/products/substance-painter) projects for advanced custom skinning. You can also download and modify any of our [example texture sets](Exported%20Texture%20Sets).
 
 ![UV Layout example](docs/UVLayout.jpg)
 
@@ -35,14 +38,15 @@ The UV layout for the base robot avatar is purposefully symmetrical along the X 
 
 ![Panda Bot example](docs/PandaBot.jpg)
 
-The simplest version of re-skinning the robot avatar would be to simply paint a 'baseColor' map. However, because Hubs uses glTF standards it supports many of the map types associated with [physically-based materials](https://www.allegorithmic.com/pbr-guide). 
+The simplest version of re-skinning the robot avatar would be to simply paint a 'baseColor' map. However, because Hubs uses glTF standards it supports many of the map types associated with [physically-based materials](https://www.allegorithmic.com/pbr-guide).
 The default avatar is currently using:
+
 - Base Color
 - Emissive
 - Normal
 - Ambient Occlusion
 - Roughness (black = glossy, white = rough)
-- Metallic  (black = non-metal, white = fully metallic)
+- Metallic (black = non-metal, white = fully metallic)
 
 **NOTE: Ambient Occlusion, Roughness, and Metallic must be combined in one singular image with each texture occupying the Red, Green, and Blue channels respectively.** This is sometimes referred to as an _'ORM'_ texture.
 
@@ -52,9 +56,9 @@ The default avatar is currently using:
 
 We offer the following resources if you'd like to modify our Robot avatar:
 
-* [Blender Source Files](Blender/AvatarBot) are available of our Robot avatar. **For specific information about how to use these .blend files, be sure to check out the readme within the [Blender/AvatarBot](/Blender/AvatarBot) folder.**
+- [Blender Source Files](Blender/AvatarBot) are available of our Robot avatar. **For specific information about how to use these .blend files, be sure to check out the readme within the [Blender/AvatarBot](/Blender/AvatarBot) folder.**
 
-* [Exported GLBs](Exported%20GLB%20models)/[Exported OBJ](Other%20model%20formats)  are available if you'd like to bring them into your editor of choice.
+- [Exported GLBs](Exported%20GLB%20models)/[Exported OBJ](Other%20model%20formats) are available if you'd like to bring them into your editor of choice.
 
 We recommend using [The lastest stable version of Blender](https://builder.blender.org/download/) for custom models since we have provided example files that you may use as a guide. (Typically, skeleton setup varies between modeling appications which can make importing/exporting skeletons a bit tricky due to unexpected changes in bone rotations, but it is still possible to use something other than Blender.) Note: the .blend files were created with [Blender](https://builder.blender.org/download/) due to the built-in glTF exporter. The glTF importer/exporter for Blender is currently in rapid development. Expect some bugs and [please report them!](https://github.com/KhronosGroup/glTF-Blender-IO/issues)
 
@@ -62,7 +66,7 @@ Hubs avatars are meant for VR, which means that you should work in real world un
 
 ![avatar height diagram](docs/avatarHeight.jpg)
 
-Files with the suffix *_base* refer to the most barebones, basic robot avatar template that can be used as a reference when creating new avatar models. Typically, the Blender workflow would be to either 'Link' or 'Append' the objects from [AvatarBot_base_for_export.blend](/Blender/AvatarBot) in order to use the existing armature (skeleton) and any animations that go along with it, using them as a basis for your own model that you would attach to it.
+Files with the suffix _\_base_ refer to the most barebones, basic robot avatar template that can be used as a reference when creating new avatar models. Typically, the Blender workflow would be to either 'Link' or 'Append' the objects from [AvatarBot_base_for_export.blend](/Blender/AvatarBot) in order to use the existing armature (skeleton) and any animations that go along with it, using them as a basis for your own model that you would attach to it.
 
 The armature is based largely upon the same hierarchy and naming conventions of the skeleton provided by [High Fidelity](https://docs.highfidelity.com/en/rc80/create/avatars/avatar-standards.html#skeleton). This also happens to have a similar structure to VRChat in terms of bone orientations.
 However, in our current implementation in Hubs, we have eliminated some of the bones within the hierarchy, namely the lower body and arm joints since we are not using any sort of inverse kinematics (IK) at the moment. This may change in future iterations.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
-# Avatar assets and templates for Hubs
+# Avatar assets and templates for Mozilla Hubs
 
-This contains some useful working files for editing avatars for Hubs
+This contains some useful working files for editing avatars for Hubs 
 
-**IMPORTANT: If you are cloning this repo, _you MUST first install [GitLFS](https://git-lfs.github.com/)_ or else many of the files will not work.**
+**IMPORTANT:  If you are cloning this repo, _you MUST first install [GitLFS](https://git-lfs.github.com/)_ or else many of the files will not work.**
 
 Depending on how involved you'd like to get in the avatar creation process, you might choose to simply 're-skin' the existing robot avatar by painting your own texture maps, or create your own fully custom 3D model.
 
 ## Reduce Cloning Size
-
 Cloning the full repository can be difficult on a slow connection due to its large size. The majority of this comes from `Substance/`, which is several GB, and is not necessary unless you intend on using Substance Painter when customizing an avatar. If you do not intend to modify the avatars using Substance Painter, you can exclude the files in `Substance/` from being downloaded by GitLFS by following these commands:
-
 ```
 mkdir hubs-avatar-pipelines && cd hubs-avatar-pipelines
 git init
-git remote add -f origin https://github.com/Hubs-Foundation/hubs-avatar-pipelines.git
+git remote add -f origin https://github.com/MozillaReality/hubs-avatar-pipelines.git
 git config lfs.fetchexclude "Substance"
 git pull origin master
 ```
-
 This reduces the project download size from several GB to less than one GB.
 
 ## Making your own custom avatar skin
@@ -26,11 +23,11 @@ A quick and easy way to create a custom avatar in Hubs is to create a custom ski
 
 You can use the following resources:
 
-- [Quilt](https://tryquilt.io/) - A simple tool put together by the Hubs team for quickly re-skinning the default Hubs robot avatar.
+* [Quilt](https://tryquilt.io/) - A simple tool put together by the Hubs team for quickly re-skinning the default Hubs robot avatar. 
 
-- [Photoshop PSD Templates](Photoshop) - Photoshop templates for a custom Hubs base color skin. You can also use Photoshop's 3D painting tools, using the [Robot OBJ/MAT file](https://github.com/j-conrad/hubs-avatar-pipelines/tree/master/Other%20model%20formats).
+* [Photoshop PSD Templates](Photoshop) - Photoshop templates for a custom Hubs base color skin. You can also use Photoshop's 3D painting tools, using the [Robot OBJ/MAT file](https://github.com/j-conrad/hubs-avatar-pipelines/tree/master/Other%20model%20formats).
 
-- [Substaince Painter Project](Substance) - Full [Substance Painter](https://www.allegorithmic.com/products/substance-painter) projects for advanced custom skinning. You can also download and modify any of our [example texture sets](Exported%20Texture%20Sets).
+* [Substaince Painter Project](Substance) - Full [Substance Painter](https://www.allegorithmic.com/products/substance-painter) projects for advanced custom skinning. You can also download and modify any of our [example texture sets](Exported%20Texture%20Sets).
 
 ![UV Layout example](docs/UVLayout.jpg)
 
@@ -38,15 +35,14 @@ The UV layout for the base robot avatar is purposefully symmetrical along the X 
 
 ![Panda Bot example](docs/PandaBot.jpg)
 
-The simplest version of re-skinning the robot avatar would be to simply paint a 'baseColor' map. However, because Hubs uses glTF standards it supports many of the map types associated with [physically-based materials](https://www.allegorithmic.com/pbr-guide).
+The simplest version of re-skinning the robot avatar would be to simply paint a 'baseColor' map. However, because Hubs uses glTF standards it supports many of the map types associated with [physically-based materials](https://www.allegorithmic.com/pbr-guide). 
 The default avatar is currently using:
-
 - Base Color
 - Emissive
 - Normal
 - Ambient Occlusion
 - Roughness (black = glossy, white = rough)
-- Metallic (black = non-metal, white = fully metallic)
+- Metallic  (black = non-metal, white = fully metallic)
 
 **NOTE: Ambient Occlusion, Roughness, and Metallic must be combined in one singular image with each texture occupying the Red, Green, and Blue channels respectively.** This is sometimes referred to as an _'ORM'_ texture.
 
@@ -56,9 +52,9 @@ The default avatar is currently using:
 
 We offer the following resources if you'd like to modify our Robot avatar:
 
-- [Blender Source Files](Blender/AvatarBot) are available of our Robot avatar. **For specific information about how to use these .blend files, be sure to check out the readme within the [Blender/AvatarBot](/Blender/AvatarBot) folder.**
+* [Blender Source Files](Blender/AvatarBot) are available of our Robot avatar. **For specific information about how to use these .blend files, be sure to check out the readme within the [Blender/AvatarBot](/Blender/AvatarBot) folder.**
 
-- [Exported GLBs](Exported%20GLB%20models)/[Exported OBJ](Other%20model%20formats) are available if you'd like to bring them into your editor of choice.
+* [Exported GLBs](Exported%20GLB%20models)/[Exported OBJ](Other%20model%20formats)  are available if you'd like to bring them into your editor of choice.
 
 We recommend using [The lastest stable version of Blender](https://builder.blender.org/download/) for custom models since we have provided example files that you may use as a guide. (Typically, skeleton setup varies between modeling appications which can make importing/exporting skeletons a bit tricky due to unexpected changes in bone rotations, but it is still possible to use something other than Blender.) Note: the .blend files were created with [Blender](https://builder.blender.org/download/) due to the built-in glTF exporter. The glTF importer/exporter for Blender is currently in rapid development. Expect some bugs and [please report them!](https://github.com/KhronosGroup/glTF-Blender-IO/issues)
 
@@ -66,7 +62,7 @@ Hubs avatars are meant for VR, which means that you should work in real world un
 
 ![avatar height diagram](docs/avatarHeight.jpg)
 
-Files with the suffix _\_base_ refer to the most barebones, basic robot avatar template that can be used as a reference when creating new avatar models. Typically, the Blender workflow would be to either 'Link' or 'Append' the objects from [AvatarBot_base_for_export.blend](/Blender/AvatarBot) in order to use the existing armature (skeleton) and any animations that go along with it, using them as a basis for your own model that you would attach to it.
+Files with the suffix *_base* refer to the most barebones, basic robot avatar template that can be used as a reference when creating new avatar models. Typically, the Blender workflow would be to either 'Link' or 'Append' the objects from [AvatarBot_base_for_export.blend](/Blender/AvatarBot) in order to use the existing armature (skeleton) and any animations that go along with it, using them as a basis for your own model that you would attach to it.
 
 The armature is based largely upon the same hierarchy and naming conventions of the skeleton provided by [High Fidelity](https://docs.highfidelity.com/en/rc80/create/avatars/avatar-standards.html#skeleton). This also happens to have a similar structure to VRChat in terms of bone orientations.
 However, in our current implementation in Hubs, we have eliminated some of the bones within the hierarchy, namely the lower body and arm joints since we are not using any sort of inverse kinematics (IK) at the moment. This may change in future iterations.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Avatar assets and templates for Mozilla Hubs
+# Avatar assets and templates for Hubs
 
 This contains some useful working files for editing avatars for Hubs 
 
@@ -11,7 +11,7 @@ Cloning the full repository can be difficult on a slow connection due to its lar
 ```
 mkdir hubs-avatar-pipelines && cd hubs-avatar-pipelines
 git init
-git remote add -f origin https://github.com/MozillaReality/hubs-avatar-pipelines.git
+git remote add -f origin https://github.com/Hubs-Foundation/hubs-avatar-pipelines.git
 git config lfs.fetchexclude "Substance"
 git pull origin master
 ```


### PR DESCRIPTION
Small update to swap in the new Hubs Foundation repo URL in the Hubs Avatar Pipelines readme.